### PR TITLE
Changed const Strings& ref inside NetFiler to not be a reference.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # Copyright (c) 2011-2015 Stefan Eilemann <Stefan.Eilemann@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(hwsd VERSION 1.3.0)
+project(hwsd VERSION 1.3.1)
 set(hwsd_VERSION_ABI 3)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake

--- a/hwsd/filter.cpp
+++ b/hwsd/filter.cpp
@@ -223,7 +223,7 @@ public:
         , type( type_ )
     {}
 
-    const lunchbox::Strings& prefixes;
+    const lunchbox::Strings prefixes;
     const uint32_t type;
 };
 }


### PR DESCRIPTION
The user can't know that NefFilter is storing a reference to the
parameter passed at construction. Documenting the behaviour is not the
right solution to keep the reference beacuse it'd be easy to overlook.
Passing a pointer would be a better choice because it makes more explicit
the fact that the class is going to store the reference (at least makes the
user wonder what would happen to the pointer).
To not change the API a copy will be done instead.