### PR TITLE
Fixes for several issues in systems with multiple X Servers:

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,8 @@
 # Copyright (c) 2011-2015 Stefan Eilemann <Stefan.Eilemann@epfl.ch>
 
 cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
-project(hwsd VERSION 1.4.0)
-set(hwsd_VERSION_ABI 3)
+project(hwsd VERSION 2.0.0)
+set(hwsd_VERSION_ABI 4)
 
 list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/CMake
   ${CMAKE_SOURCE_DIR}/CMake/common)

--- a/doc/Changelog.md
+++ b/doc/Changelog.md
@@ -3,6 +3,12 @@
 
 # git master
 
+* [56](https://github.com/Eyescale/hwsd/pull/55):
+  - Added a new flag to GPUInfo to identify which is the default display under X.
+  - Removed GPUInfo::defaultValue.
+  - GPU filter fixed to also consider the port numbers.
+  - Do not probe display ports greater than 9 under X to avoid opening ssh -X
+    virtual displays.
 * [55](https://github.com/Eyescale/hwsd/pull/55): Fix memory corruption
   with SessionFilter
 * [49](https://github.com/Eyescale/hwsd/pull/47): Added a command line options

--- a/hwsd/filter.cpp
+++ b/hwsd/filter.cpp
@@ -116,6 +116,7 @@ bool MirrorFilter::operator() ( const GPUInfos& current,
         const GPUInfo& info = *i;
         if( info.id == candidate.id &&
             info.session == candidate.session &&
+            info.port == candidate.port &&
             info.device == candidate.device &&
             info.pvp[0] == candidate.pvp[0] && info.pvp[1] == candidate.pvp[1] )
         {

--- a/hwsd/gpu/dns_sd/module.cpp
+++ b/hwsd/gpu/dns_sd/module.cpp
@@ -107,13 +107,11 @@ bool Module::announce( const std::string& session ) const
         // GPU<integer> Type=GLX | WGL | WGLn | CGL
         _impl->setValue( index, GPUTYPE, info.getName( ));
 
-        if( info.port != GPUInfo::defaultValue )
-            // GPU<integer> Port=<integer> // X11 display number, 0 otherwise
-            _impl->setValue( index, GPUPORT, info.port );
+        // GPU<integer> Port=<integer> // X11 display number, 0 otherwise
+        _impl->setValue( index, GPUPORT, info.port );
 
-        if( info.device != GPUInfo::defaultValue )
-            // GPU<integer> Device=<integer> // X11 display number, 0 otherwise
-            _impl->setValue( index, GPUDEVICE, info.device );
+        // GPU<integer> Device=<integer> // X11 display number, 0 otherwise
+        _impl->setValue( index, GPUDEVICE, info.device );
 
         if( info.pvp[2] > 0 && info.pvp[3] > 0 )
         {

--- a/hwsd/gpu/glx/module.cpp
+++ b/hwsd/gpu/glx/module.cpp
@@ -128,11 +128,7 @@ GPUInfos Module::discover() const
         const std::string display( displayEnv );
         if( queryDisplay_( display, defaultInfo ))
         {
-            if( display[0] != ':' )
-            {
-                defaultInfo.port = GPUInfo::defaultValue;
-                defaultInfo.device = GPUInfo::defaultValue;
-            }
+            defaultInfo.flags = GPUInfo::FLAG_DEFAULT;
             result.push_back( defaultInfo );
 #ifdef __APPLE__
             // OS X only has one X server, but launchd magic makes duplicate
@@ -156,7 +152,7 @@ GPUInfos Module::discover() const
                 if( info != defaultInfo )
                     result.push_back( info );
             }
-            else if( j == 0 && i >= TRY_PORTS )
+            else if( j == 0 && i > TRY_PORTS )
                 // X Server does not exist, stop query
                 return result;
             else // X Screen does not exist, try next server

--- a/hwsd/gpuInfo.cpp
+++ b/hwsd/gpuInfo.cpp
@@ -21,8 +21,8 @@ namespace hwsd
 {
     GPUInfo::GPUInfo()
         : type( 0 )
-        , port( defaultValue )
-        , device( defaultValue )
+        , port( 0 )
+        , device( 0 )
         , flags( 0 )
         , unused( 0 )
     {
@@ -31,8 +31,8 @@ namespace hwsd
 
     GPUInfo::GPUInfo( const std::string& name )
         : type( 0 )
-        , port( defaultValue )
-        , device( defaultValue )
+        , port( 0 )
+        , device( 0 )
         , flags( 0 )
         , unused( 0 )
     {

--- a/hwsd/gpuInfo.h
+++ b/hwsd/gpuInfo.h
@@ -32,9 +32,6 @@ namespace hwsd
 /** A structure containing GPU-specific information. */
 struct GPUInfo : public NodeInfo
 {
-    /** A non-enumerated port or device. @version 1.0 */
-    static const unsigned defaultValue = UINT_MAX;
-
     /** Process runs under VirtualGL. @version 1.1.2 */
     static const unsigned FLAG_VIRTUALGL = 0x1;
 
@@ -46,14 +43,23 @@ struct GPUInfo : public NodeInfo
 	@version 1.2.1 */
     static const unsigned FLAG_VNC = 0x4;
 
-    /** Default constructor pointing to the default display. @version 1.0 */
+    /** Default GPU pointed by the DISPLAY variable (GLX only). */
+    static const unsigned FLAG_DEFAULT = 0x8;
+
+
+    /** Default constructor.
+
+        Port and device have undefined values in the initial state.
+        @version 2.0 */
     HWSD_API GPUInfo();
 
     /**
-     * Constructor pointing to default display of a specific GPU type.
+     * Constructor taking a specific GPU type.
      *
      * The information name is a type code of four characters. The passed string
      * is formatted accordingly.
+     *
+     * Port and device have undefined values in the initial state.
      *
      * @param name the type of the GPU.
      * @version 1.0
@@ -96,10 +102,8 @@ inline std::ostream& operator << ( std::ostream& os, const GPUInfo& info )
     os << "GPUInfo\n" << static_cast< const NodeInfo& >( info );
     if( !info.getName().empty( ))
         os << "  Type      " << info.getName() << std::endl;
-    if( info.port != GPUInfo::defaultValue )
-        os << "  Port      " << info.port << std::endl;
-    if( info.device != GPUInfo::defaultValue )
-        os << "  Device    " << info.device << std::endl;
+    os << "  Port      " << info.port << std::endl;
+    os << "  Device    " << info.device << std::endl;
     if( info.pvp[2] >0 && info.pvp[3] > 0 )
         os << "  Viewport  [" << info.pvp[0] << ' ' << info.pvp[1] << ' '
            << info.pvp[2] << ' ' << info.pvp[3] << ']' << std::endl;


### PR DESCRIPTION
- The port number was not considered on GPUFilter. This was
  causing GPUs to be discarded just because the ID was the same.
- Servers from ssh -X were also probed.

A new flag to detect which GPU comes from DISPLAY has been added.
GPUInfo::defaultValue has been removed as it doesn't provide any additional
value.